### PR TITLE
Adding thin as the webserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "sinatra-flash"
 gem "bcrypt-ruby"
 gem "pg"
 
+gem 'thin'
+
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,10 +26,12 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     coderay (1.1.0)
+    daemons (1.2.3)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    eventmachine (1.0.8)
     i18n (0.7.0)
     json (1.8.2)
     minitest (5.7.0)
@@ -64,6 +66,10 @@ GEM
       sinatra (~> 1.0)
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thread_safe (0.3.5)
     tilt (2.0.1)
     tzinfo (1.2.2)
@@ -85,3 +91,4 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   sinatra-flash
+  thin


### PR DESCRIPTION
Webrick is not a production quality webserver

So add `gem 'thin'` to your Gemfile so that when your app runs on Heroku it is more robust

@1UnboundedSentience
@Plisonousbess
@anujaverma11
@BenjamH
@benvogcodes
@brenguyen711
@cpbasham
@NorCalDavid
@dknittel
@lee-egist
@erinbeitel
@HoomanGriz
@jbomotti
@Jareedos
@lisaSwanson
@ashbymichael
@philipyoo
@sunghyukpark
@knosis
@Tom2277
@traceycarterDBC
@Vrturo
@wildraj
@zakairobbins
@zoeingram
